### PR TITLE
Fix: Random crash on entering config portal from config mode due to PROGMEM inconsistencies

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -13,3 +13,9 @@
 
 - https://github.com/esp8266/Arduino
 - https://github.com/bblanchon/ArduinoJson
+
+## Note
+
+Do **not** use the Board Manager to install the ESP8266 core.    
+Clone from github into ~/Documents/hardware instead, as described in the documentation.
+Else, you will likely end up using the wrong SDK and run into problems.

--- a/iSpindel/WiFiManagerKT.cpp
+++ b/iSpindel/WiFiManagerKT.cpp
@@ -528,7 +528,8 @@ void WiFiManager::handleWifi() {
       pitem = FPSTR(HTTP_FORM_PARAM);
     break;
   }
-
+  
+    String customHTML = reinterpret_cast<const __FlashStringHelper *>(_params[i]->getCustomHTML());
     if (_params[i]->getID() != NULL) {
       pitem.replace("{i}", _params[i]->getID());
       pitem.replace("{n}", _params[i]->getID());
@@ -536,9 +537,9 @@ void WiFiManager::handleWifi() {
       snprintf(parLength, 2, "%d", _params[i]->getValueLength());
       pitem.replace("{l}", parLength);
       pitem.replace("{v}", _params[i]->getValue());
-      pitem.replace("{c}", _params[i]->getCustomHTML());
+      pitem.replace("{c}", customHTML);
     } else {
-      pitem = _params[i]->getCustomHTML();
+      pitem = customHTML;
     }
 
     page += pitem;


### PR DESCRIPTION
There was a weird condition when compiled code would crash the ESP9266, depending on what host OS and/or Arduino IDE version it was compiled on.    
After lots of debugging, it turns out this has to do with PROGMEM.    
The WiFiManagerParameter api_list has no properties set besides HTTP_API_LIST, which seems to (sometimes) cause problems when directly referencing it, being then (sometimes) read incorrectly from flash memory and causing a type 3 exception.    
This **very** hard-to-find fix should restore compatibility across platforms and IDE versions.    
Might want to keep this in mind, should similar problems arise with other "v0g0n" PROGMEM char[]s in the future, fingers crossed.