### PR TITLE
Gravity.reset

### DIFF
--- a/tools/generic-TCP/INSTALL.md
+++ b/tools/generic-TCP/INSTALL.md
@@ -12,6 +12,14 @@ Falls die Datenbank schon besteht, muss in die Tabelle "Data" ein neues Feld ein
 
 Bei einer Neuinstallation ist dies bereits im Folgenden berücksichtigt.
 
+### Update für Resetflag bei Grafiken:
+Um bei den Grafiken das Resetflag nutzen zu können, muss, falls die Datenbank schon besteht, in die Tabelle "Data" ein neues Feld eingefügt werden:
+
+	USE iSpindle;
+	ALTER TABLE Data ADD ResetFlag boolean;
+
+Bei einer Neuinstallation ist dies bereits im Folgenden berücksichtigt.
+
 ### Vorbemerkung:
 Es mag so aussehen, als würde hier viel zu viel Ballast installiert, das geht alles auch schlanker.
 Stimmt.

--- a/tools/generic-TCP/INSTALL.md
+++ b/tools/generic-TCP/INSTALL.md
@@ -85,6 +85,14 @@ Die Datentabelle folgt diesem Schema:
 
 (Im Feld ID wird die Hardware ID abgelegt, welche wir zum Hinterlegen der Kalibrierung benötigen.)     
 
+	CREATE TABLE `Calibration` (
+		`ID` varchar(64) COLLATE ascii_bin NOT NULL,
+		`const1` double NOT NULL,
+		`const2` double NOT NULL,
+		`const3` double NOT NULL,
+		PRIMARY KEY (`ID`)
+		) ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin COMMENT='iSpindle Calibration Data';
+
 #### Benutzer anlegen und berechtigen (und ihm ein eigenes Passwort geben):
 
 	CREATE USER 'iSpindle' IDENTIFIED BY 'xxxxxxxxxx';

--- a/tools/generic-TCP/INSTALL.md
+++ b/tools/generic-TCP/INSTALL.md
@@ -70,11 +70,8 @@ Die Datentabelle folgt diesem Schema:
  		`Angle` double NOT NULL,
  		`Temperature` double NOT NULL,
  		`Battery` double NOT NULL,
-<<<<<<< HEAD
 		`ResetFlag` boolean,
-=======
 		`Gravity` double NOT NULL DEFAULT 0,
->>>>>>> refs/remotes/universam1/master
  	PRIMARY KEY (`Timestamp`,`Name`,`ID`)
 	) ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin COMMENT='iSpindle Data'
 

--- a/tools/generic-TCP/INSTALL.md
+++ b/tools/generic-TCP/INSTALL.md
@@ -81,7 +81,7 @@ Die Datentabelle folgt diesem Schema:
 		`ResetFlag` boolean,
 		`Gravity` double NOT NULL DEFAULT 0,
  	PRIMARY KEY (`Timestamp`,`Name`,`ID`)
-	) ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin COMMENT='iSpindle Data'
+	) ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin COMMENT='iSpindle Data';
 
 (Im Feld ID wird die Hardware ID abgelegt, welche wir zum Hinterlegen der Kalibrierung benötigen.)     
 

--- a/tools/generic-TCP/INSTALL.md
+++ b/tools/generic-TCP/INSTALL.md
@@ -60,6 +60,7 @@ Die Datentabelle folgt diesem Schema:
  		`Angle` double NOT NULL,
  		`Temperature` double NOT NULL,
  		`Battery` double NOT NULL,
+		`ResetFlag` boolean,
  	PRIMARY KEY (`Timestamp`,`Name`,`ID`)
 	) ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin COMMENT='iSpindle Data'
 

--- a/tools/generic-TCP/INSTALL_en.md
+++ b/tools/generic-TCP/INSTALL_en.md
@@ -59,6 +59,7 @@ Otherwise, the main data table will suffice:
  		`Angle` double NOT NULL,
  		`Temperature` double NOT NULL,
  		`Battery` double NOT NULL,
+		`ResetFlag` boolean,
  	PRIMARY KEY (`Timestamp`,`Name`,`ID`)
 	) ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin COMMENT='iSpindle Data'
 

--- a/tools/generic-TCP/INSTALL_en.md
+++ b/tools/generic-TCP/INSTALL_en.md
@@ -83,6 +83,14 @@ Otherwise, the main data table will suffice:
 
 The field "ID" stores the iSpindle's unique hardware ID, which we'll need in order to use calibration.
 
+	CREATE TABLE `Calibration` (
+		`ID` varchar(64) COLLATE ascii_bin NOT NULL,
+		`const1` double NOT NULL,
+		`const2` double NOT NULL,
+		`const3` double NOT NULL,
+		PRIMARY KEY (`ID`)
+		) ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin COMMENT='iSpindle Calibration Data';
+
 #### Create a Database User, Grant Permissions, Set Password):
 
 	CREATE USER 'iSpindle' IDENTIFIED BY 'password';

--- a/tools/generic-TCP/INSTALL_en.md
+++ b/tools/generic-TCP/INSTALL_en.md
@@ -68,11 +68,8 @@ Otherwise, the main data table will suffice:
  		`Angle` double NOT NULL,
  		`Temperature` double NOT NULL,
  		`Battery` double NOT NULL,
-<<<<<<< HEAD
 		`ResetFlag` boolean,
-=======
 		`Gravity` double NOT NULL DEFAULT 0,
->>>>>>> refs/remotes/universam1/master
  	PRIMARY KEY (`Timestamp`,`Name`,`ID`)
 	) ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin COMMENT='iSpindle Data'
 

--- a/tools/generic-TCP/INSTALL_en.md
+++ b/tools/generic-TCP/INSTALL_en.md
@@ -79,7 +79,7 @@ Otherwise, the main data table will suffice:
 		`ResetFlag` boolean,
 		`Gravity` double NOT NULL DEFAULT 0,
  	PRIMARY KEY (`Timestamp`,`Name`,`ID`)
-	) ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin COMMENT='iSpindle Data'
+	) ENGINE=InnoDB DEFAULT CHARSET=ascii COLLATE=ascii_bin COMMENT='iSpindle Data';
 
 The field "ID" stores the iSpindle's unique hardware ID, which we'll need in order to use calibration.
 

--- a/tools/generic-TCP/INSTALL_en.md
+++ b/tools/generic-TCP/INSTALL_en.md
@@ -10,6 +10,14 @@ If you already have this running and want to update to the new firmware, you'll 
 
 This is already taken into account if you newly install this and follow the instructions below.
 
+### Update for Resetflag for charts:
+To use the charts with the parameter Resetflag, you'll need to add a new column to the Data table:
+
+	USE iSpindle;
+	ALTER TABLE Data ADD ResetFlag boolean;
+
+This is already taken into account if you newly install this and follow the instructions below.
+
 ### Preliminary Remarks:
 
 These recommended software requirements might seem like overkill, but this solution is highly flexible and wide open for future enhancements.    

--- a/tools/generic-TCP/MySQL_CreateTables.sql
+++ b/tools/generic-TCP/MySQL_CreateTables.sql
@@ -5,6 +5,7 @@ CREATE TABLE `Data` (
        `Angle` double NOT NULL,
        `Temperature` double NOT NULL,
        `Battery` double NOT NULL,
+       `ResetFlag` boolean,
 	PRIMARY KEY (`Timestamp`, `Name`, `ID`)
 	) 
 ENGINE=InnoDB DEFAULT CHARSET=ascii 

--- a/tools/generic-TCP/MySQL_CreateTables.sql
+++ b/tools/generic-TCP/MySQL_CreateTables.sql
@@ -5,11 +5,8 @@ CREATE TABLE `Data` (
        `Angle` double NOT NULL,
        `Temperature` double NOT NULL,
        `Battery` double NOT NULL,
-<<<<<<< HEAD
        `ResetFlag` boolean,
-=======
        `Gravity` double NOT NULL DEFAULT 0,
->>>>>>> refs/remotes/universam1/master
 	PRIMARY KEY (`Timestamp`, `Name`, `ID`)
 	) 
 ENGINE=InnoDB DEFAULT CHARSET=ascii 

--- a/tools/generic-TCP/README.md
+++ b/tools/generic-TCP/README.md
@@ -91,6 +91,7 @@ Um die Tabelle mit den grundlegenden Feldern anzulegen, verwendet man am besten 
 		'Angle' double NOT NULL,
 		'Temperature' double NOT NULL,
 		'Battery' double NOT NULL,
+		'ResetFlag' boolean,
 		PRIMARY KEY ('Timestamp', 'Name', 'ID')
 	) 
 	ENGINE=InnoDB DEFAULT CHARSET=ascii 

--- a/tools/generic-TCP/README.md
+++ b/tools/generic-TCP/README.md
@@ -94,11 +94,8 @@ Um die Tabelle mit den grundlegenden Feldern anzulegen, verwendet man am besten 
 		'Angle' double NOT NULL,
 		'Temperature' double NOT NULL,
 		'Battery' double NOT NULL,
-<<<<<<< HEAD
 		'ResetFlag' boolean,
-=======
 		'Gravity' double NOT NULL,
->>>>>>> refs/remotes/universam1/master
 		PRIMARY KEY ('Timestamp', 'Name', 'ID')
 	) 
 	ENGINE=InnoDB DEFAULT CHARSET=ascii 

--- a/tools/generic-TCP/README_en.md
+++ b/tools/generic-TCP/README_en.md
@@ -92,6 +92,7 @@ In order to create a table inside your MySQL database accordingly, use this SQL 
 		'Angle' double NOT NULL,
 		'Temperature' double NOT NULL,
 		'Battery' double NOT NULL,
+		'ResetFlag' boolean,
 		PRIMARY KEY ('Timestamp', 'Name', 'ID')
 	) 
 	ENGINE=InnoDB DEFAULT CHARSET=ascii 

--- a/tools/generic-TCP/README_en.md
+++ b/tools/generic-TCP/README_en.md
@@ -94,11 +94,8 @@ In order to create a table inside your MySQL database accordingly, use this SQL 
 		'Angle' double NOT NULL,
 		'Temperature' double NOT NULL,
 		'Battery' double NOT NULL,
-<<<<<<< HEAD
 		'ResetFlag' boolean,
-=======
 		'Gravity' double NOT NULL,
->>>>>>> refs/remotes/universam1/master
 		PRIMARY KEY ('Timestamp', 'Name', 'ID')
 	) 
 	ENGINE=InnoDB DEFAULT CHARSET=ascii 

--- a/tools/generic-TCP/web/README.md
+++ b/tools/generic-TCP/web/README.md
@@ -32,7 +32,7 @@ Beispiele:
 * http://meinraspi/iSpindle/status.php?name=MeineSpindel2
 
 Mit reset_now kann man einen Zeitstempel (Beginn der Gärung) festlegen und bei der Grafik alle Werte nach diesem Zeitstempel anzeigen:
-* http://meinraspi/iSpindle//reset_now.php?name=MeineSpindel2
+* http://meinraspi/iSpindle/reset_now.php?name=MeineSpindel2
 * http://meinraspi/iSpindle/angle.php?name=MeineSpindel2&reset=true
 
 Dafür kann man dann Lesezeichen anlegen und so auch auf einem Touchscreen schnell zur gewünschten Ansicht kommen.     

--- a/tools/generic-TCP/web/README.md
+++ b/tools/generic-TCP/web/README.md
@@ -30,6 +30,10 @@ Beispiele:
 * http://meinraspi/iSpindle/angle.php?name=MeineSpindel1&hours=24
 * http://meinraspi/iSpindle/status.php?name=MeineSpindel2
 
+Mit reset_now kann man einen Zeitstempel (Beginn der Gärung) festlegen und bei der Grafik alle Werte nach diesem Zeitstempel anzeigen:
+* http://meinraspi/iSpindle//reset_now.php?name=MeineSpindel2
+* http://meinraspi/iSpindle/angle.php?name=MeineSpindel2&reset=true
+
 Dafür kann man dann Lesezeichen anlegen und so auch auf einem Touchscreen schnell zur gewünschten Ansicht kommen.     
 
 Ich hoffe, damit einen sinnvollen Grundstein gelegt zu haben, auf dem Ihr aufbauen könnt.

--- a/tools/generic-TCP/web/README_en.md
+++ b/tools/generic-TCP/web/README_en.md
@@ -22,7 +22,7 @@ In order to show these charts we pass arguments via GET in order to be able to b
 * http://raspi/iSpindle/status.php?name=MySpindle2
 
 reset_now defines a timestamp (start of fermentation) and the graph shows only the entries after this timestamp:
-* http://meinraspi/iSpindle//reset_now.php?name=MeineSpindel2
+* http://meinraspi/iSpindle/reset_now.php?name=MeineSpindel2
 * http://meinraspi/iSpindle/angle.php?name=MeineSpindel2&reset=true
 
 I hope I've built sort of a foundation with templates for lots of future enhancements.

--- a/tools/generic-TCP/web/README_en.md
+++ b/tools/generic-TCP/web/README_en.md
@@ -21,7 +21,7 @@ In order to show these charts we pass arguments via GET in order to be able to b
 * http://raspi/iSpindle/angle.php?name=MySpindle1&hours=24
 * http://raspi/iSpindle/status.php?name=MySpindle2
 
-reset_now defines a timestamp (start of fermentation) festlegen and the graph shows only the entries after this timestamp:
+reset_now defines a timestamp (start of fermentation) and the graph shows only the entries after this timestamp:
 * http://meinraspi/iSpindle//reset_now.php?name=MeineSpindel2
 * http://meinraspi/iSpindle/angle.php?name=MeineSpindel2&reset=true
 

--- a/tools/generic-TCP/web/README_en.md
+++ b/tools/generic-TCP/web/README_en.md
@@ -20,6 +20,10 @@ In order to show these charts we pass arguments via GET in order to be able to b
 * http://raspi/iSpindle/angle.php?name=MySpindle1&hours=24
 * http://raspi/iSpindle/status.php?name=MySpindle2
 
+reset_now defines a timestamp (start of fermentation) festlegen and the graph shows only the entries after this timestamp:
+* http://meinraspi/iSpindle//reset_now.php?name=MeineSpindel2
+* http://meinraspi/iSpindle/angle.php?name=MeineSpindel2&reset=true
+
 I hope I've built sort of a foundation with templates for lots of future enhancements.
 I am aware that there's probably a ton of things I could have solved more elegantly and there's room for improvement galore.     
 Contributions are by all means welcome. Looking forward!

--- a/tools/generic-TCP/web/angle.php
+++ b/tools/generic-TCP/web/angle.php
@@ -125,9 +125,9 @@ $(function ()
         formatter: function() 
         {
 	   if(this.series.name == 'Temperatur') {
-           	return '<b>'+ this.series.name +' </b>um '+ Highcharts.dateFormat('%H:%M', new Date(this.x)) +' Uhr:  '+ this.y +'Â°C';
+           	return '<b>'+ this.series.name +' </b>um '+ Highcharts.dateFormat('%H:%M', new Date(this.x)) +' Uhr:  '+ this.y +'°C';
 	   } else {
-	   	return '<b>'+ this.series.name +' </b>um '+ Highcharts.dateFormat('%H:%M', new Date(this.x)) +' Uhr:  '+ this.y +'Â°';
+	   	return '<b>'+ this.series.name +' </b>um '+ Highcharts.dateFormat('%H:%M', new Date(this.x)) +' Uhr:  '+ this.y +'°';
 	   }
         }
       },  

--- a/tools/generic-TCP/web/angle.php
+++ b/tools/generic-TCP/web/angle.php
@@ -9,10 +9,11 @@ include_once("include/common_db.php");
 include_once("include/common_db_query.php");
 
 // Check GET parameters (for now: Spindle name and Timeframe to display) 
-if(!isset($_GET['hours'])) $_GET['hours'] = 24; else $_GET['hours'] = $_GET['hours'];
+if(!isset($_GET['hours'])) $_GET['hours'] = defaultTimePeriod; else $_GET['hours'] = $_GET['hours'];
 if(!isset($_GET['name'])) $_GET['name'] = 'iSpindel000'; else $_GET['name'] = $_GET['name'];
+if(!isset($_GET['reset'])) $_GET['reset'] = defaultReset; else $_GET['reset'] = $_GET['reset'];
 
-list($angle, $temperature) = getChartValues($_GET['name'], $_GET['hours']);
+list($angle, $temperature) = getChartValues($_GET['name'], $_GET['hours'], $_GET['reset']);
 
 ?>
 
@@ -51,8 +52,18 @@ $(function ()
         text: 'iSpindel: <?php echo $_GET['name'];?>'
       },
       subtitle: 
-      {
-        text: 'Temperatur und Winkel der letzten <?php echo $_GET['hours'];?> Stunden'
+      { text:
+       ' <?php               
+          if($_GET['reset']) 
+             {     
+             echo 'Temperatur und Winkel seit dem letzten Reset';
+             }
+           else
+             {
+             echo 'Temperatur und Winkel den letzten '.  $_GET['hours'] .  ' Stunden';
+             }
+        ?>'
+        
       },
       xAxis: 
       {
@@ -114,9 +125,9 @@ $(function ()
         formatter: function() 
         {
 	   if(this.series.name == 'Temperatur') {
-           	return '<b>'+ this.series.name +' </b>um '+ Highcharts.dateFormat('%H:%M', new Date(this.x)) +' Uhr:  '+ this.y +'°C';
+           	return '<b>'+ this.series.name +' </b>um '+ Highcharts.dateFormat('%H:%M', new Date(this.x)) +' Uhr:  '+ this.y +'Â°C';
 	   } else {
-	   	return '<b>'+ this.series.name +' </b>um '+ Highcharts.dateFormat('%H:%M', new Date(this.x)) +' Uhr:  '+ this.y +'°';
+	   	return '<b>'+ this.series.name +' </b>um '+ Highcharts.dateFormat('%H:%M', new Date(this.x)) +' Uhr:  '+ this.y +'Â°';
 	   }
         }
       },  

--- a/tools/generic-TCP/web/include/common_db.php
+++ b/tools/generic-TCP/web/include/common_db.php
@@ -15,4 +15,5 @@ if(is_resource($conn))
 }
  
 define("defaultTimePeriod", 24); // Timeframe for chart
+define("defaultReset",  false);  // Flag for Timeframe for chart, 
 ?>

--- a/tools/generic-TCP/web/include/common_db_query.php
+++ b/tools/generic-TCP/web/include/common_db_query.php
@@ -21,14 +21,25 @@ function delLastChar($string="")
 }
  
 // Get values from database for selected spindle, between now and timeframe in hours ago
-function getChartValues($iSpindleID='iSpindel000', $timeFrameHours=24)
+function getChartValues($iSpindleID='iSpindel000', $timeFrameHours=defaultTimePeriod, $reset=defaultReset)
 {
-  $q_sql = mysql_query("SELECT UNIX_TIMESTAMP(Timestamp) as unixtime, temperature, angle
-                          FROM Data
-                          WHERE Name = '".$iSpindleID."' AND Timestamp >= date_sub(NOW(), INTERVAL ".$timeFrameHours." HOUR) and Timestamp <= NOW()
-                          ORDER BY Timestamp ASC") or die(mysql_error());
-                          
-
+   if ($reset)
+   {
+   $where="WHERE Name = '".$iSpindleID."' 
+                  AND Timestamp >= (Select max(Timestamp) FROM data  WHERE ResetFlag = true AND Name = '".$iSpindleID."')";
+   }  
+   else
+   {
+  $where ="WHERE Name = '".$iSpindleID."' 
+            AND Timestamp >= date_sub(NOW(), INTERVAL ".$timeFrameHours." HOUR) 
+            and Timestamp <= NOW()";
+   }  
+   $q_sql = mysql_query("SELECT UNIX_TIMESTAMP(Timestamp) as unixtime, temperature, angle
+                         FROM Data " 
+                         .$where 
+                         ." ORDER BY Timestamp ASC") 
+                        or die(mysql_error());
+   
   // retrieve number of rows
   $rows = mysql_num_rows($q_sql);
   if ($rows > 0)
@@ -55,9 +66,9 @@ function getChartValues($iSpindleID='iSpindel000', $timeFrameHours=24)
 function getCurrentValues($iSpindleID='iSpindel000')
 {
    $q_sql = mysql_query("SELECT UNIX_TIMESTAMP(Timestamp) as unixtime, temperature, angle, battery
-			    FROM Data
-			    WHERE Name = '".$iSpindleID."'
-			    ORDER BY Timestamp DESC LIMIT 1") or die (mysql_error());
+                FROM Data
+                WHERE Name = '".$iSpindleID."'
+                ORDER BY Timestamp DESC LIMIT 1") or die (mysql_error());
 
   $rows = mysql_num_rows($q_sql);                                                                                         
   if ($rows > 0)                                                                                                          
@@ -72,7 +83,7 @@ function getCurrentValues($iSpindleID='iSpindel000')
 }
                         
 // Get calibrated values from database for selected spindle, between now and [number of hours] ago
-function getChartValuesPlato($iSpindleID='iSpindel000', $timeFrameHours=24)
+function getChartValuesPlato($iSpindleID='iSpindel000', $timeFrameHours=defaultTimePeriod, $reset=defaultReset)
 {
     $isCalibrated = 0;  // is there a calbration record for this iSpindle?
     $valAngle = '';
@@ -82,10 +93,22 @@ function getChartValuesPlato($iSpindleID='iSpindel000', $timeFrameHours=24)
     $const2 = 0;
     $const3 = 0;
 
-    $q_sql = mysql_query("SELECT UNIX_TIMESTAMP(Timestamp) as unixtime, temperature, angle
-                         FROM Data
-                         WHERE Name = '".$iSpindleID."' AND Timestamp >= date_sub(NOW(), INTERVAL ".$timeFrameHours." HOUR) and Timestamp <= NOW()
-                         ORDER BY Timestamp ASC") or die(mysql_error());
+   if ($reset)
+   {
+   $where="WHERE Name = '".$iSpindleID."' 
+                  AND Timestamp >= (Select max(Timestamp) FROM data  WHERE ResetFlag = true AND Name = '".$iSpindleID."')";
+   }  
+   else
+   {
+  $where ="WHERE Name = '".$iSpindleID."' 
+            AND Timestamp >= date_sub(NOW(), INTERVAL ".$timeFrameHours." HOUR) 
+            and Timestamp <= NOW()";
+   }  
+   $q_sql = mysql_query("SELECT UNIX_TIMESTAMP(Timestamp) as unixtime, temperature, angle
+                           FROM Data " 
+                           .$where 
+                           ." ORDER BY Timestamp ASC")
+                           or die(mysql_error());
                      
     // retrieve number of rows
     $rows = mysql_num_rows($q_sql);

--- a/tools/generic-TCP/web/include/common_db_query.php
+++ b/tools/generic-TCP/web/include/common_db_query.php
@@ -37,8 +37,7 @@ function getChartValues($iSpindleID='iSpindel000', $timeFrameHours=defaultTimePe
    $q_sql = mysql_query("SELECT UNIX_TIMESTAMP(Timestamp) as unixtime, temperature, angle
                          FROM Data " 
                          .$where 
-                         ." ORDER BY Timestamp ASC") 
-                        or die(mysql_error());
+                         ." ORDER BY Timestamp ASC") or die(mysql_error());
    
   // retrieve number of rows
   $rows = mysql_num_rows($q_sql);
@@ -63,12 +62,24 @@ function getChartValues($iSpindleID='iSpindel000', $timeFrameHours=defaultTimePe
 }
 
 // Get values from database including gravity (Fw 5.0.1 required) for selected spindle, between now and timeframe in hours ago
-function getChartValuesPlato($iSpindleID='iSpindel000', $timeFrameHours=24)
+function getChartValuesPlato($iSpindleID='iSpindel000', $timeFrameHours=defaultTimePeriod, $reset=defaultReset)
 {
+   if ($reset)
+   {
+   $where="WHERE Name = '".$iSpindleID."' 
+                  AND Timestamp >= (Select max(Timestamp) FROM data  WHERE ResetFlag = true AND Name = '".$iSpindleID."')";
+   }  
+   else
+   {
+  $where ="WHERE Name = '".$iSpindleID."' 
+            AND Timestamp >= date_sub(NOW(), INTERVAL ".$timeFrameHours." HOUR) 
+            and Timestamp <= NOW()";
+   }  
+   
   $q_sql = mysql_query("SELECT UNIX_TIMESTAMP(Timestamp) as unixtime, temperature, angle, gravity
-                          FROM Data
-                          WHERE Name = '".$iSpindleID."' AND Timestamp >= date_sub(NOW(), INTERVAL ".$timeFrameHours." HOUR) and Timestamp <= NOW()
-                          ORDER BY Timestamp ASC") or die(mysql_error());
+                          FROM Data " 
+                         .$where 
+                         ." ORDER BY Timestamp ASC") or die(mysql_error());
 
 
   // retrieve number of rows
@@ -85,13 +96,13 @@ function getChartValuesPlato($iSpindleID='iSpindel000', $timeFrameHours=24)
       $jsTime = $r_row['unixtime'] * 1000;
       $valAngle         .= '['.$jsTime.', '.$r_row['angle'].'],';
       $valTemperature   .= '['.$jsTime.', '.$r_row['temperature'].'],';
-      $valGravity 	.= '['.$jsTime.', '.$r_row['gravity'].'],';
+      $valGravity       .= '['.$jsTime.', '.$r_row['gravity'].'],';
     }
 
     // remove last comma from each CSV
     $valAngle         = delLastChar($valAngle);
     $valTemperature   = delLastChar($valTemperature);
-    $valGravity	      = delLastChar($valGravity);
+    $valGravity       = delLastChar($valGravity);
     return array($valAngle, $valTemperature, $valGravity);
   }
 }
@@ -117,12 +128,8 @@ function getCurrentValues($iSpindleID='iSpindel000')
 }
                         
 // Get calibrated values from database for selected spindle, between now and [number of hours] ago
-<<<<<<< HEAD
-function getChartValuesPlato($iSpindleID='iSpindel000', $timeFrameHours=defaultTimePeriod, $reset=defaultReset)
-=======
 // Old Method for Firmware before 5.x
-function getChartValuesPlato4($iSpindleID='iSpindel000', $timeFrameHours=24)
->>>>>>> refs/remotes/universam1/master
+function getChartValuesPlato4($iSpindleID='iSpindel000', $timeFrameHours=defaultTimePeriod, $reset=defaultReset)
 {
     $isCalibrated = 0;  // is there a calbration record for this iSpindle?
     $valAngle = '';
@@ -146,8 +153,7 @@ function getChartValuesPlato4($iSpindleID='iSpindel000', $timeFrameHours=24)
    $q_sql = mysql_query("SELECT UNIX_TIMESTAMP(Timestamp) as unixtime, temperature, angle
                            FROM Data " 
                            .$where 
-                           ." ORDER BY Timestamp ASC")
-                           or die(mysql_error());
+                           ." ORDER BY Timestamp ASC") or die(mysql_error());
                      
     // retrieve number of rows
     $rows = mysql_num_rows($q_sql);
@@ -190,4 +196,3 @@ function getChartValuesPlato4($iSpindleID='iSpindel000', $timeFrameHours=24)
     }
  }
 ?>
-

--- a/tools/generic-TCP/web/include/common_db_query.php
+++ b/tools/generic-TCP/web/include/common_db_query.php
@@ -26,7 +26,7 @@ function getChartValues($iSpindleID='iSpindel000', $timeFrameHours=defaultTimePe
    if ($reset)
    {
    $where="WHERE Name = '".$iSpindleID."' 
-                  AND Timestamp >= (Select max(Timestamp) FROM data  WHERE ResetFlag = true AND Name = '".$iSpindleID."')";
+                  AND Timestamp >= (Select max(Timestamp) FROM Data  WHERE ResetFlag = true AND Name = '".$iSpindleID."')";
    }  
    else
    {

--- a/tools/generic-TCP/web/include/common_db_query.php
+++ b/tools/generic-TCP/web/include/common_db_query.php
@@ -38,6 +38,7 @@ function getChartValues($iSpindleID='iSpindel000', $timeFrameHours=defaultTimePe
                          FROM Data " 
                          .$where 
                          ." ORDER BY Timestamp ASC") or die(mysql_error());
+                         
   // retrieve number of rows
   $rows = mysql_num_rows($q_sql);
   if ($rows > 0)
@@ -74,7 +75,6 @@ function getChartValuesPlato($iSpindleID='iSpindel000', $timeFrameHours=defaultT
             AND Timestamp >= date_sub(NOW(), INTERVAL ".$timeFrameHours." HOUR) 
             and Timestamp <= NOW()";
    }  
-      
   $q_sql = mysql_query("SELECT UNIX_TIMESTAMP(Timestamp) as unixtime, temperature, angle, gravity
                           FROM Data " 
                          .$where 

--- a/tools/generic-TCP/web/include/common_db_query.php
+++ b/tools/generic-TCP/web/include/common_db_query.php
@@ -38,7 +38,6 @@ function getChartValues($iSpindleID='iSpindel000', $timeFrameHours=defaultTimePe
                          FROM Data " 
                          .$where 
                          ." ORDER BY Timestamp ASC") or die(mysql_error());
-   
   // retrieve number of rows
   $rows = mysql_num_rows($q_sql);
   if ($rows > 0)
@@ -75,12 +74,11 @@ function getChartValuesPlato($iSpindleID='iSpindel000', $timeFrameHours=defaultT
             AND Timestamp >= date_sub(NOW(), INTERVAL ".$timeFrameHours." HOUR) 
             and Timestamp <= NOW()";
    }  
-   
+      
   $q_sql = mysql_query("SELECT UNIX_TIMESTAMP(Timestamp) as unixtime, temperature, angle, gravity
                           FROM Data " 
                          .$where 
                          ." ORDER BY Timestamp ASC") or die(mysql_error());
-
 
   // retrieve number of rows
   $rows = mysql_num_rows($q_sql);
@@ -114,7 +112,7 @@ function getCurrentValues($iSpindleID='iSpindel000')
                 FROM Data
                 WHERE Name = '".$iSpindleID."'
                 ORDER BY Timestamp DESC LIMIT 1") or die (mysql_error());
-
+  
   $rows = mysql_num_rows($q_sql);                                                                                         
   if ($rows > 0)                                                                                                          
   {
@@ -138,7 +136,6 @@ function getChartValuesPlato4($iSpindleID='iSpindel000', $timeFrameHours=default
     $const1 = 0;
     $const2 = 0;
     $const3 = 0;
-
    if ($reset)
    {
    $where="WHERE Name = '".$iSpindleID."' 
@@ -150,10 +147,11 @@ function getChartValuesPlato4($iSpindleID='iSpindel000', $timeFrameHours=default
             AND Timestamp >= date_sub(NOW(), INTERVAL ".$timeFrameHours." HOUR) 
             and Timestamp <= NOW()";
    }  
+   
    $q_sql = mysql_query("SELECT UNIX_TIMESTAMP(Timestamp) as unixtime, temperature, angle
                            FROM Data " 
                            .$where 
-                           ." ORDER BY Timestamp ASC") or die(mysql_error());
+                          ." ORDER BY Timestamp ASC") or die(mysql_error());
                      
     // retrieve number of rows
     $rows = mysql_num_rows($q_sql);
@@ -167,7 +165,7 @@ function getChartValuesPlato4($iSpindleID='iSpindel000', $timeFrameHours=default
         // try to get calibration for iSpindle hardware ID
         $r_id = mysql_fetch_array($u_sql);
         $uniqueID = $r_id['ID'];
-        $f_sql = mysql_query("SELECT const1, const2, const3 FROM Calibration WHERE ID = ".$uniqueID) or die(mysql_error());
+        $f_sql = mysql_query("SELECT const1, const2, const3 FROM Calibration WHERE ID = '$uniqueID' ") or die(mysql_error());
         $rows_cal = mysql_num_rows($f_sql);
         if ($rows_cal > 0)
         {

--- a/tools/generic-TCP/web/plato.php
+++ b/tools/generic-TCP/web/plato.php
@@ -13,7 +13,7 @@ if(!isset($_GET['hours'])) $_GET['hours'] = defaultTimePeriod; else $_GET['hours
 if(!isset($_GET['name'])) $_GET['name'] = 'iSpindel000'; else $_GET['name'] = $_GET['name'];
 if(!isset($_GET['reset'])) $_GET['reset'] = defaultReset; else $_GET['reset'] = $_GET['reset'];
 
-list($angle, $temperature, $dens) = getChartValuesPlato($_GET['name'], $_GET['reset']);
+list($angle, $temperature, $dens) = getChartValuesPlato($_GET['name'],$_GET['hours'], $_GET['reset']);
 
 ?>
 

--- a/tools/generic-TCP/web/plato.php
+++ b/tools/generic-TCP/web/plato.php
@@ -9,10 +9,11 @@ include_once("include/common_db.php");
 include_once("include/common_db_query.php");
 
 // Check GET parameters (for now: Spindle name and Timeframe to display) 
-if(!isset($_GET['hours'])) $_GET['hours'] = 24; else $_GET['hours'] = $_GET['hours'];
+if(!isset($_GET['hours'])) $_GET['hours'] = defaultTimePeriod; else $_GET['hours'] = $_GET['hours'];
 if(!isset($_GET['name'])) $_GET['name'] = 'iSpindel000'; else $_GET['name'] = $_GET['name'];
+if(!isset($_GET['reset'])) $_GET['reset'] = defaultReset; else $_GET['reset'] = $_GET['reset'];
 
-list($angle, $temperature, $dens) = getChartValuesPlato($_GET['name'], $_GET['hours']);
+list($angle, $temperature, $dens) = getChartValuesPlato($_GET['name'], $_GET['reset']);
 
 ?>
 
@@ -52,7 +53,17 @@ $(function ()
             },
             subtitle:
             {
-                text: 'Temperatur und Restextrakt der letzten <?php echo $_GET['hours'];?> Stunden'
+              text: ' <?php               
+                         if($_GET['reset']) 
+                         {     
+                            echo 'Temperatur und Winkel seit dem letzten Reset';
+                         }
+                         else
+                         {
+                            echo 'Temperatur und Winkel den letzten '.  $_GET['hours'] .  ' Stunden';
+                         }
+                      ?>
+                    '
             },
             xAxis:
             {
@@ -80,7 +91,7 @@ $(function ()
                         y: 16,
                         formatter: function()
                         {
-                            return this.value + '˚P'
+                            return this.value + '°P'
                         }
                     },
                     showFirstLabel: false

--- a/tools/generic-TCP/web/plato4.php
+++ b/tools/generic-TCP/web/plato4.php
@@ -9,10 +9,11 @@ include_once("include/common_db.php");
 include_once("include/common_db_query.php");
 
 // Check GET parameters (for now: Spindle name and Timeframe to display) 
-if(!isset($_GET['hours'])) $_GET['hours'] = 24; else $_GET['hours'] = $_GET['hours'];
+if(!isset($_GET['hours'])) $_GET['hours'] = defaultTimePeriod; else $_GET['hours'] = $_GET['hours'];
 if(!isset($_GET['name'])) $_GET['name'] = 'iSpindel000'; else $_GET['name'] = $_GET['name'];
+if(!isset($_GET['reset'])) $_GET['reset'] = defaultReset; else $_GET['reset'] = $_GET['reset'];
 
-list($isCalib, $dens, $temperature, $angle) = getChartValuesPlato4($_GET['name'], $_GET['hours']);
+list($isCalib, $dens, $temperature, $angle) = getChartValuesPlato4($_GET['name'], $_GET['hours'], $_GET['reset']);
 
 ?>
 
@@ -59,7 +60,17 @@ $(function ()
             },
             subtitle:
             {
-                text: 'Temperatur und Restextrakt der letzten <?php echo $_GET['hours'];?> Stunden'
+              text: ' <?php               
+                         if($_GET['reset']) 
+                         {     
+                            echo 'Temperatur und Restextrakt seit dem letzten Reset';
+                         }
+                         else
+                         {
+                            echo 'Temperatur und Restextrakt den letzten '.  $_GET['hours'] .  ' Stunden';
+                         }
+                      ?>
+                    '
             },
             xAxis:
             {
@@ -87,7 +98,7 @@ $(function ()
                         y: 16,
                         formatter: function()
                         {
-                            return this.value + '˚P'
+                            return this.value + '°P'
                         }
                     },
                     showFirstLabel: false

--- a/tools/generic-TCP/web/reset_now.php
+++ b/tools/generic-TCP/web/reset_now.php
@@ -8,7 +8,7 @@ if(!isset($_GET['name'])) $_GET['name'] = 'iSpindel000'; else $_GET['name'] = $_
 
 $Name = $_GET['name'];
 
-$q_sql = mysql_query( "INSERT INTO data (Timestamp, Name, resetFlag)
+$q_sql = mysql_query( "INSERT INTO Data (Timestamp, Name, resetFlag)
                       VALUES (NOW(),'$Name', true)")
                        or die(mysql_error());
                        

--- a/tools/generic-TCP/web/reset_now.php
+++ b/tools/generic-TCP/web/reset_now.php
@@ -1,0 +1,22 @@
+<?php
+ include_once("include/common_db.php");
+include_once("include/common_db_query.php");
+
+// Check GET parameters 
+if(!isset($_GET['name'])) $_GET['name'] = 'iSpindel000'; else $_GET['name'] = $_GET['name'];
+
+
+$Name = $_GET['name'];
+
+$q_sql = mysql_query( "INSERT INTO data (Timestamp, Name, resetFlag)
+                      VALUES (NOW(),'$Name', true)")
+                       or die(mysql_error());
+                       
+if (! $q_sql){
+   echo "Fehler beim Insert";
+}
+else {
+   echo "Reset-Timestamp in Datenbank eingetragen";
+}
+?>
+


### PR DESCRIPTION
Erweiterung von Tozzis generic-TCP-Datenbank um die Spalte ResetFlag und Anpassungen der Grafiken. Mit dem ResetFlag kann man sich den aktuellen Sud leichter anzeigen. Hierzu setzt man (z.B. zu Beginn der Gärung) mittels reset_now.php einen Zeitstempel in der Datenbank und kann bei den Grafiken mit den zusätzlichen Parameter reset=true nur die Daten anzeigen lassen, die nach den Zeitstempel in die Datenbank eingetragen wurden.