### PR TITLE
Use ESP8266 pin numbers

### DIFF
--- a/iSpindel/Globals.h
+++ b/iSpindel/Globals.h
@@ -52,7 +52,7 @@ extern Ticker flasher;
 #define PORTALTIMEOUT 300
 
 #define ADCDIVISOR 191.8
-#define ONE_WIRE_BUS D6  // DS18B20 on ESP pin12
+#define ONE_WIRE_BUS 12 // on Wemos D1 mini pin D6
 #define RESOLUTION 12 // 12bit resolution == 750ms update rate
 #define OWinterval (800 / (1 << (12 - RESOLUTION))) 
 #define CFGFILE "/config.json"

--- a/iSpindel/iSpindel.ino
+++ b/iSpindel/iSpindel.ino
@@ -555,7 +555,7 @@ void initDS18B20()
 void initAccel()
 {
   // join I2C bus (I2Cdev library doesn't do this automatically)
-  Wire.begin(D3, D4);
+  Wire.begin(4, 5); // On Wemos D1 mini pins D3, D4
   Wire.setClock(100000);
   Wire.setClockStretchLimit(2 * 230);
 


### PR DESCRIPTION
allows to use different ESP8266 boards without changing code. e.g.
Adafruit HUZZAH ESP8266