### PR TITLE
Add ChipId to data for FHEM

### DIFF
--- a/pio/src/iSpindel.cpp
+++ b/pio/src/iSpindel.cpp
@@ -469,6 +469,7 @@ bool uploadData(uint8_t service)
     sender.add("temperature", Temperatur);
     sender.add("battery", Volt);
     sender.add("gravity", Gravity);
+    sender.add("ID", ESP.getChipId());
     SerialOut(F("\ncalling FHEM"));
     return sender.sendFHEM(my_server, my_port, my_name);
   }


### PR DESCRIPTION
Signed-off-by: Christoph Willing <chris.willing@linux.com>

This PR adds "ID" field to FHEM API (as already provided in generic http API). This is not currently provided in FHEM API where it would be useful e.g. in case of distinguishing multiple devices connecting to same server when user has forgotten to configure different names.