### PR TITLE
Add an english 'breadboard mounting' section to the README (with pics)

### DIFF
--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -82,10 +82,11 @@ The software calculates the Euler angle for X and Y from the XYZ acceleration va
 
 ### see [Parts](Parts_en.md)
 
-
 ### see [Sourcing](Parts_en.md)
 
-### [Circuit Diagram](circuit_diagram_en.md)
+### see [Circuit Diagram](circuit_diagram_en.md)
+
+### see [iSpindel Breabboard Mounting](iSpindelbreadboard_en.md)
 
 ***
 

--- a/docs/iSpindelbreadboard_en.md
+++ b/docs/iSpindelbreadboard_en.md
@@ -1,0 +1,30 @@
+# Construction variant A: perforated grid & sled
+
+> The view of the pictures is always *** left *** shows direction cover/USB port of the Wemos.
+
+1. Pin the pin from below. This reduces the build-up height so everything fits into the petling.
+![](/pics/BB/1.jpg)
+1. Insert the short and long bushing strip and solder the Wemos.
+![](/pics/BB/2.jpg)
+1. Leave the 4 left pins.
+![](/pics/BB/3.jpg)
+1. Remove the GY-521 LED. The right 4 pins must not have any contact.
+![](/pics/BB/4.jpg)
+1. Place wire bridges, resistors and switches. Soldering top makes it easier.
+![](/pics/BB/5.jpg)
+![](/pics/BB/6.jpg)
+1. Lower the wires according to the following diagram.
+![](/pics/BB/7.jpg)
+
+1. Solder the DS18B20, only the middle pin is pinched by the resistor on the pin of the Wemo. Do not connect the other two (Vcc, GND) to the Wemos.
+![](/pics/BB/8.jpg)
+
+1. Remove the Wemos diode.
+Install the 4 pins for the lipo charger TP4056. The connections are marked in red.
+![](/pics/BB/9.jpg)
+
+1. Solder the charging module, the battery is soldered to it.
+![](/pics/BB/10.jpg)
+
+1. Assembled with the carriage viewed from below.
+![](/pics/BB/11.jpg)


### PR DESCRIPTION
I simply add a breadboard mounting section, in english, available from the README, to be able to see your mounting pics (which are great).