### PR TITLE
Overload add for uint32_t (as returned by getChipId())

### DIFF
--- a/pio/lib/Sender/Sender.cpp
+++ b/pio/lib/Sender/Sender.cpp
@@ -22,6 +22,10 @@ void SenderClass::add(String id, String value)
 {
     _jsonVariant[id] = value;
 }
+void SenderClass::add(String id, uint32_t value)
+{
+    _jsonVariant[id] = value;
+}
 
 bool SenderClass::send(String server, String url, uint16_t port)
 {

--- a/pio/lib/Sender/Sender.h
+++ b/pio/lib/Sender/Sender.h
@@ -21,12 +21,13 @@ public:
   bool sendTCONTROL(String server, uint16_t port);
   void add(String id, float value);
   void add(String id, String value);
+  void add(String id, uint32_t value);
   // ~SenderClass();
 
 private:
   WiFiClient _client;
   // StaticJsonBuffer<200> _jsonBuffer;
-  DynamicJsonBuffer _jsonBuffer;  
+  DynamicJsonBuffer _jsonBuffer;
   // JsonObject data;
   JsonVariant _jsonVariant;
 };


### PR DESCRIPTION
Signed-off-by: Christoph Willing <chris.willing@linux.com>

Replaces #112 and fixes #111 correctly (I think).