### PR TITLE
Add temp units to output (Closes #186)

### DIFF
--- a/pio/src/iSpindel.cpp
+++ b/pio/src/iSpindel.cpp
@@ -101,6 +101,19 @@ float scaleTemperature(float t)
     return t; // Invalid value for my_tempscale => default to celsius
 }
 
+String tempScaleLabel(void)
+{
+  if (my_tempscale == TEMP_CELSIUS)
+    return "C";
+  else if (my_tempscale == TEMP_FAHRENHEIT)
+    return "F";
+  else if (my_tempscale == TEMP_KELVIN)
+    return "K";
+  else
+    return "C"; // Invalid value for my_tempscale => default to celsius
+}
+
+
 // callback notifying us of the need to save config
 void saveConfigCallback()
 {
@@ -515,6 +528,7 @@ bool uploadData(uint8_t service)
   {
     sender.add("tilt", Tilt);
     sender.add("temperature", scaleTemperature(Temperatur));
+    sender.add("temp_units", tempScaleLabel())
     sender.add("battery", Volt);
     sender.add("gravity", Gravity);
     sender.add("interval", my_sleeptime);
@@ -529,6 +543,7 @@ bool uploadData(uint8_t service)
   {
     sender.add("tilt", Tilt);
     sender.add("temperature", scaleTemperature(Temperatur));
+    sender.add("temp_units", tempScaleLabel())
     sender.add("battery", Volt);
     sender.add("gravity", Gravity);
     sender.add("interval", my_sleeptime);
@@ -563,6 +578,7 @@ bool uploadData(uint8_t service)
       sender.add("token", my_token);
     sender.add("angle", Tilt);
     sender.add("temperature", scaleTemperature(Temperatur));
+    sender.add("temp_units", tempScaleLabel())
     sender.add("battery", Volt);
     sender.add("gravity", Gravity);
     sender.add("interval", my_sleeptime);
@@ -598,6 +614,7 @@ bool uploadData(uint8_t service)
   {
     sender.add("angle", Tilt);
     sender.add("temperature", scaleTemperature(Temperatur));
+    sender.add("temp_units", tempScaleLabel())
     sender.add("battery", Volt);
     sender.add("gravity", Gravity);
     sender.add("ID", ESP.getChipId());
@@ -675,7 +692,7 @@ void sleepManager()
 
 void requestTemp()
 {
-  if (DSrequested == false)
+  if (!DSrequested)
   {
     DS18B20.requestTemperatures();
     DSreqTime = millis();

--- a/pio/src/iSpindel.cpp
+++ b/pio/src/iSpindel.cpp
@@ -528,7 +528,7 @@ bool uploadData(uint8_t service)
   {
     sender.add("tilt", Tilt);
     sender.add("temperature", scaleTemperature(Temperatur));
-    sender.add("temp_units", tempScaleLabel())
+    sender.add("temp_units", tempScaleLabel());
     sender.add("battery", Volt);
     sender.add("gravity", Gravity);
     sender.add("interval", my_sleeptime);
@@ -543,7 +543,7 @@ bool uploadData(uint8_t service)
   {
     sender.add("tilt", Tilt);
     sender.add("temperature", scaleTemperature(Temperatur));
-    sender.add("temp_units", tempScaleLabel())
+    sender.add("temp_units", tempScaleLabel());
     sender.add("battery", Volt);
     sender.add("gravity", Gravity);
     sender.add("interval", my_sleeptime);
@@ -578,7 +578,7 @@ bool uploadData(uint8_t service)
       sender.add("token", my_token);
     sender.add("angle", Tilt);
     sender.add("temperature", scaleTemperature(Temperatur));
-    sender.add("temp_units", tempScaleLabel())
+    sender.add("temp_units", tempScaleLabel());
     sender.add("battery", Volt);
     sender.add("gravity", Gravity);
     sender.add("interval", my_sleeptime);
@@ -614,7 +614,7 @@ bool uploadData(uint8_t service)
   {
     sender.add("angle", Tilt);
     sender.add("temperature", scaleTemperature(Temperatur));
-    sender.add("temp_units", tempScaleLabel())
+    sender.add("temp_units", tempScaleLabel());
     sender.add("battery", Volt);
     sender.add("gravity", Gravity);
     sender.add("ID", ESP.getChipId());


### PR DESCRIPTION
With the recent addition of the ability to automatically convert the temperature being sent downstream to units other than Celsius, downstream receivers of iSpindel data could no longer determine the units of temperature they were being provided. As a result, for those consumers who had built conversion functionality, the assumption that the temperature being provided was in Celsius was no longer true. This results in users seeing [wildly inaccurate temperatures](https://www.homebrewtalk.com/forum/threads/native-esp8266-brewpi-firmware-wifi-brewpi-no-arduino-needed.586476/page-52#post-8362123) if units other than Celsius were selected on the iSpindel.

This pull request adds a new field that is sent along with the scaled temperature that contains a character label for the units of temperature in use (C, F, or K). 