### PR TITLE
Add messages to return code and limit connection attempt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ iSpindel/__vm/
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/.browse.c_cpp.db*
+.clang_complete
+.gcc-flags.json

--- a/pio/lib/Globals/Globals.h
+++ b/pio/lib/Globals/Globals.h
@@ -109,4 +109,7 @@ extern MPU6050_Base accelgyro;
 extern bool saveConfig();
 extern void formatSpiffs();
 
+float scaleTemperature(float t);
+String tempScaleLabel(void);
+
 #endif

--- a/pio/lib/Sender/Sender.cpp
+++ b/pio/lib/Sender/Sender.cpp
@@ -39,7 +39,9 @@ bool SenderClass::sendMQTT(String server, uint16_t port, String username, String
     _mqttClient.setServer(server.c_str(), port);
     _mqttClient.setCallback([this](char *topic, byte *payload, unsigned int length) { this->mqttCallback(topic, payload, length); });
 
-    while (!_mqttClient.connected())
+    byte i = 0;
+
+    while (!_mqttClient.connected() && (i < 3))
     {
         CONSOLELN(F("Attempting MQTT connection"));
         // Attempt to connect
@@ -49,10 +51,51 @@ bool SenderClass::sendMQTT(String server, uint16_t port, String username, String
         }
         else
         {
-            CONSOLELN(F("Failed MQTT connection, return code:"));
-            CONSOLELN(_mqttClient.state());
+            CONSOLE(F("Failed MQTT connection, return code:"));
+
+            int Status = _mqttClient.state();
+
+            switch (Status)
+            {
+            case -4:
+              CONSOLELN(F("Connection timeout"));
+              break;
+
+            case -3:
+              CONSOLELN(F("Connection lost"));
+              break;
+
+            case -2:
+              CONSOLELN(F("Connect failed"));
+              break;
+
+            case -1:
+              CONSOLELN(F("Disconnected"));
+              break;
+
+            case 1:
+              CONSOLELN(F("Bad protocol"));
+              break;
+
+            case 2:
+              CONSOLELN(F("Bad client ID"));
+              break;
+
+            case 3:
+              CONSOLELN(F("Unavailable"));
+              break;
+
+            case 4:
+              CONSOLELN(F("Bad credentials"));
+              break;
+
+            case 5:
+              CONSOLELN(F("Unauthorized"));
+              break;
+            }
             CONSOLELN(F("Retrying MQTT connection in 5 seconds"));
             // Wait 5 seconds before retrying
+            i++;
             delay(5000);
         }
     }

--- a/pio/lib/WiFiManagerKT/WiFiManagerKT.cpp
+++ b/pio/lib/WiFiManagerKT/WiFiManagerKT.cpp
@@ -969,8 +969,10 @@ void WiFiManager::handleiSpindel()
   page += Tilt;
   page += F("&deg;</td></tr>");
   page += F("<tr><td>Temperature:</td><td>");
-  page += Temperatur;
-  page += F("&deg;C</td></tr>");
+  page += scaleTemperature(Temperatur);
+  page += F("&deg;");
+  page += tempScaleLabel();
+  page += F("</td></tr>");
   page += F("<tr><td>Battery:</td><td>");
   page += Volt;
   page += F("V</td></tr>");


### PR DESCRIPTION
It will prevent waste all the battery when the broker is down and add some readable messages for debug purpose.