### PR TITLE
Fix: InfluxDB HTTP error 400 #215

### DIFF
--- a/pio/lib/Sender/Sender.cpp
+++ b/pio/lib/Sender/Sender.cpp
@@ -221,7 +221,12 @@ bool SenderClass::sendInfluxDB(String server, uint16_t port, String db, String n
     {
         msg += kv.key;
         msg += "=";
-        msg += kv.value.as<String>();
+        // check if value is of type char, if so set value in double quotes
+	if ( kv.value.is<char*>() ) {
+            msg += '"' + kv.value.as<String>() + '"';
+        }else{
+            msg += kv.value.as<String>();
+        }
         msg += ",";
     }
     msg.remove(msg.length() - 1);

--- a/pio/lib/Sender/Sender.cpp
+++ b/pio/lib/Sender/Sender.cpp
@@ -222,7 +222,7 @@ bool SenderClass::sendInfluxDB(String server, uint16_t port, String db, String n
         msg += kv.key;
         msg += "=";
         // check if value is of type char, if so set value in double quotes
-	if ( kv.value.is<char*>() ) {
+        if ( kv.value.is<char*>() ) {
             msg += '"' + kv.value.as<String>() + '"';
         }else{
             msg += kv.value.as<String>();


### PR DESCRIPTION
Fixing issue #215 
single char values must be set in quotes, otherwise influx thinks that the char should be treated as a boolean. If the char is other than y or n, influx says that the boolean could not be recognized.