### PR TITLE
Added MQTTJSON API provider

### DIFF
--- a/pio/lib/Globals/Globals.h
+++ b/pio/lib/Globals/Globals.h
@@ -31,6 +31,7 @@ extern Ticker flasher;
 #define API_MQTT true
 #define API_THINGSPEAK true
 #define API_BLYNK true
+#define API_MQTTJSON true
 
 //#define BLYNK_DEBUG
 //#define APP_DEBUG
@@ -95,6 +96,7 @@ extern Ticker flasher;
 #define DTMQTT 10
 #define DTTHINGSPEAK 11
 #define DTBLYNK 12
+#define DTMQTTJSON 13
 
 // Number of seconds after reset during which a
 // subseqent reset will be considered a double reset.

--- a/pio/lib/Sender/Sender.h
+++ b/pio/lib/Sender/Sender.h
@@ -24,6 +24,7 @@ public:
   bool sendPrometheus(String server, uint16_t port, String job, String instance);
   bool sendUbidots(String token, String name);
   bool sendMQTT(String server, uint16_t port, String username, String password, String name);
+  bool sendMQTTJSON(String server, uint16_t port, String username, String password, String name);
   bool sendFHEM(String server, uint16_t port, String name);
   bool sendTCONTROL(String server, uint16_t port);
   bool sendBlynk(char* token);

--- a/pio/lib/WiFiManagerKT/WiFiManagerKT.h
+++ b/pio/lib/WiFiManagerKT/WiFiManagerKT.h
@@ -53,7 +53,8 @@ var lAPI = [
 {"name":"Prometheus", "token":0,"server":1,"url":0,"port":1,"channel":0,"db":0,"username":0,"password":0,"job":1,"instance":1},
 {"name":"MQTT",       "token":0,"server":1,"url":0,"port":1,"channel":0,"db":0,"username":1,"password":1,"job":0,"instance":0},
 {"name":"ThingSpeak", "token":1,"server":0,"url":0,"port":0,"channel":1,"db":0,"username":0,"password":0,"job":0,"instance":0},
-{"name":"Blynk",      "token":1,"server":0,"url":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0}];
+{"name":"Blynk",      "token":1,"server":0,"url":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0},
+{"name":"MQTTJSON",       "token":0,"server":1,"url":0,"port":1,"channel":0,"db":0,"username":1,"password":1,"job":0,"instance":0}];
 
 var $ = function (id) { return document.getElementById(id); };
 var labels = document.getElementsByTagName('LABEL');

--- a/pio/src/iSpindel.cpp
+++ b/pio/src/iSpindel.cpp
@@ -573,6 +573,21 @@ bool uploadData(uint8_t service)
   }
 #endif
 
+#ifdef API_MQTTJSON
+  if (service == DTMQTTJSON)
+  {
+    sender.add("tilt", Tilt);
+    sender.add("temperature", scaleTemperature(Temperatur));
+    sender.add("temp_units", tempScaleLabel());
+    sender.add("battery", Volt);
+    sender.add("gravity", Gravity);
+    sender.add("interval", my_sleeptime);
+    sender.add("RSSI", WiFi.RSSI());
+    CONSOLELN(F("\ncalling MQTT"));
+    return sender.sendMQTTJSON(my_server, my_port, my_username, my_password, my_name);
+  }
+#endif
+
 #ifdef API_THINGSPEAK
   if (service == DTTHINGSPEAK)
   {


### PR DESCRIPTION
New API provider called "MQTTJSON" - publishes the resultset as a single json document instead of multiple topic posts. Enables ETL of data at backend. This is part of a larger effort to add TLS1.2 Client Certificate support to enable integration with AWS IoT Core and similar