### PR TITLE
Increase DynamicJsonDocument to size*3

### DIFF
--- a/pio/src/iSpindel.cpp
+++ b/pio/src/iSpindel.cpp
@@ -172,7 +172,7 @@ bool readConfig()
       else
       {
         size_t size = configFile.size();
-        DynamicJsonDocument doc(size * 2);
+        DynamicJsonDocument doc(size * 3);
         DeserializationError error = deserializeJson(doc, configFile);
         if (error)
         {


### PR DESCRIPTION
Increase DynamicJsonDocument to size*3
Shown to overcome 6.2.0 saving issues with some gyro boards