### PR TITLE
Temperature Type Selection Update

### DIFF
--- a/pio/lib/WiFiManagerKT/WiFiManagerKT.h
+++ b/pio/lib/WiFiManagerKT/WiFiManagerKT.h
@@ -90,9 +90,12 @@ window.onload = function (e) {
   }
   value = $('selAPI').value;
   sAPI(value);
-  $('TS').value = $('tempscale').value; sTS();
+  $('TS').value = $('tempscale').value;
   fillopt();
   $('API').querySelector('option[value="'+value+'"]').selected = true;
+}
+window.onchange = function (e) {
+  sTS();
 };</script>)V0G0N";
 
 const char HTTP_API_LIST[] PROGMEM = R"V0G0N(


### PR DESCRIPTION
When selecting the temp units in the in the configuration, they only seem to change if you select twice before saving. Moving the sTS; call out of the window.onload in to a window.onchange function seems to resolve it.