### PR TITLE
Patch for Blynk API for better accuracy

### DIFF
--- a/pio/lib/Globals/Globals.h
+++ b/pio/lib/Globals/Globals.h
@@ -20,7 +20,7 @@
 extern Ticker flasher;
 
 // defines go here
-#define FIRMWAREVERSION "6.4.1"
+#define FIRMWAREVERSION "6.5.0"
 
 #define API_FHEM true
 #define API_UBIDOTS true


### PR DESCRIPTION
A problem happens when data are sending to Blynk and using the specific gravity.

The specific gravity value is rounded only two digits after the decimal point, which takes away from the precision.
for example :

specific gravity read by the iSpindel: 1.052
specific gravity sent to blynk: 1.05

Thank you for the work done, this project is really awesome!