### PR TITLE
Sender: Ubidots handler 

### DIFF
--- a/pio/lib/Sender/Sender.cpp
+++ b/pio/lib/Sender/Sender.cpp
@@ -11,7 +11,7 @@
 #include <ThingSpeak.h>
 #include <BlynkSimpleEsp8266.h> //https://github.com/blynkkk/blynk-library
 
-#define UBISERVER "things.ubidots.com"
+#define UBISERVER "industrial.api.ubidots.com"
 #define BLYNKSERVER "blynk-cloud.com"
 #define CONNTIMEOUT 2000
 
@@ -381,7 +381,9 @@ bool SenderClass::sendUbidots(String token, String name)
         msg += name;
         msg += "?token=";
         msg += token;
-        msg += F(" HTTP/1.1\r\nHost: things.ubidots.com\r\nUser-Agent: ESP8266\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: ");
+        msg += F(" HTTP/1.1\r\nHost: ");
+        msg += UBISERVER;
+        msg += "\r\nUser-Agent: ESP8266\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: ");
         msg += measureJson(_doc);
         msg += "\r\n";
 

--- a/pio/lib/Sender/Sender.cpp
+++ b/pio/lib/Sender/Sender.cpp
@@ -383,7 +383,7 @@ bool SenderClass::sendUbidots(String token, String name)
         msg += token;
         msg += F(" HTTP/1.1\r\nHost: ");
         msg += UBISERVER;
-        msg += "\r\nUser-Agent: ESP8266\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: ");
+        msg += F("\r\nUser-Agent: ESP8266\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: ");
         msg += measureJson(_doc);
         msg += "\r\n";
 


### PR DESCRIPTION
changing data ingestion endpoint for Ubidots from things.ubidots.com to industrial.api.ubidots.com to be used by both STEM and Industrial accounts as Ubidots for education is deprecated