### PR TITLE
Hide AP password in the config page and on console

### DIFF
--- a/pio/lib/WiFiManagerKT/WiFiManagerKT.cpp
+++ b/pio/lib/WiFiManagerKT/WiFiManagerKT.cpp
@@ -692,8 +692,7 @@ void WiFiManager::handleWifi()
   page += FPSTR(HTTP_FORM_START1);
   page += _ssid;
   page += FPSTR(HTTP_FORM_START2);
-  // don't send existing password to web
-  //page += _pass;
+  page += _pass;
   page += FPSTR(HTTP_FORM_START3);
 
   char parLength[2];

--- a/pio/lib/WiFiManagerKT/WiFiManagerKT.cpp
+++ b/pio/lib/WiFiManagerKT/WiFiManagerKT.cpp
@@ -150,7 +150,8 @@ void WiFiManager::setupConfigPortal()
       DEBUG_WM(F("Invalid AccessPoint password. Ignoring"));
       _apPassword = NULL;
     }
-    DEBUG_WM(_apPassword);
+    //Don't show ap password on the console
+    //DEBUG_WM(_apPassword);
   }
 
   //optional soft ip config

--- a/pio/lib/WiFiManagerKT/WiFiManagerKT.cpp
+++ b/pio/lib/WiFiManagerKT/WiFiManagerKT.cpp
@@ -692,7 +692,8 @@ void WiFiManager::handleWifi()
   page += FPSTR(HTTP_FORM_START1);
   page += _ssid;
   page += FPSTR(HTTP_FORM_START2);
-  page += _pass;
+  // don't send existing password to web
+  //page += _pass;
   page += FPSTR(HTTP_FORM_START3);
 
   char parLength[2];

--- a/pio/lib/WiFiManagerKT/WiFiManagerKT.h
+++ b/pio/lib/WiFiManagerKT/WiFiManagerKT.h
@@ -118,7 +118,7 @@ const char HTTP_ITEM[] PROGMEM = "<div><a href=\"#p\" onclick=\"c(this)\">{v}</a
 const char JSON_ITEM[] PROGMEM = "{\"SSID\":\"{v}\", \"Encryption\":{i}, \"Quality\":\"{r}\"}";
 // const char HTTP_FORM_START[] PROGMEM = "<form method=\"get\" action=\"wifisave\"><label>SSID</label><input id=\"s\" name=\"s\" length=32 placeholder=\"SSID\"><label>Password</label><input id=\"p\" name=\"p\" length=64 placeholder=\"password\">";
 const char HTTP_FORM_START1[] PROGMEM = "<form method=\"get\" action=\"wifisave\"><label>SSID</label><input id=\"s\" name=\"s\" length=32 placeholder=\"SSID\" value=\"";
-const char HTTP_FORM_START2[] PROGMEM = "\"><label>Password</label><input id=\"p\" name=\"p\" length=64 placeholder=\"password\" value=\"";
+const char HTTP_FORM_START2[] PROGMEM = "\"><label>Password</label><input id=\"p\" name=\"p\" type=\"password\" length=64 placeholder=\"password\" value=\"";
 const char HTTP_FORM_START3[] PROGMEM = "\">";
 
 const char HTTP_FORM_LABEL[] PROGMEM = "<label for=\"{i}\">{p}</label>";


### PR DESCRIPTION
These commits remove display of WiFi passwords from the serial console and config pages.

The wifimanagerKT config page was missing the type="password" setting on the wifi password input field. This hides display of the wifi password. Also, if you configure the config access point to use a password, this password was shown on the console. This has been commented out but left in case someone needs it for debugging.

Note: I have not tested either of these on a board yet. Will update once I've confirmed they are working ok.