### PR TITLE
Specify Python version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -37,7 +37,7 @@ board = d1_mini
 framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
-build_flags = !python git_rev.py
+build_flags = !python3 git_rev.py
 lib_deps =
   ArduinoJson@>5
   ESP Async WebServer

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ board = d1_mini
 framework = arduino
 monitor_speed = 115200
 upload_speed = 115200
-build_flags = !python git_rev.py
+build_flags = !python3 git_rev.py
 lib_deps =
   ArduinoJson@>5
   ESP Async WebServer


### PR DESCRIPTION
Hi!

Specifying the Python version will prevent compiling error where `python` is not linked to `python3`.

```
File "git_rev.py", line 5
    print(f'\'-D FIRMWAREVERSION="{version}"\'')
                                              ^
SyntaxError: invalid syntax
OSError: 'python git_rev.py' exited 1:
  File "/home/fernandogarcia/.platformio/penv/lib/python3.7/site-packages/platformio/builder/main.py", line 177:
    env.SConscript("$BUILD_SCRIPT") 
```

Best regards.