### PR TITLE
added support for https POST

### DIFF
--- a/pio/lib/Globals/Globals.h
+++ b/pio/lib/Globals/Globals.h
@@ -90,6 +90,7 @@ extern Ticker flasher;
 #define DTBLYNK 12
 #define DTBREWBLOX 13
 #define DTAWSIOTMQTT 14             //AWS
+#define DTHTTPS 15
 
 // Number of seconds after reset during which a
 // subseqent reset will be considered a double reset.

--- a/pio/lib/Sender/Sender.cpp
+++ b/pio/lib/Sender/Sender.cpp
@@ -14,6 +14,7 @@
 #include <ESP8266HTTPClient.h>
 #include <ArduinoJson.h>
 #include <WiFiClientSecure.h>
+#include <WiFiClientSecureBearSSL.h>
 
 #define UBISERVER "industrial.api.ubidots.com"
 #define BLYNKSERVER "blynk-cloud.com"
@@ -274,6 +275,53 @@ bool SenderClass::sendThingSpeak(String token, long Channel)
     stopclient();
     return true;
     }
+
+bool SenderClass::sendHTTPSPost(String server, String uri)
+{
+    String url = server + uri;   
+    serializeJson(_doc, Serial);
+
+    String json;
+    serializeJson(_doc, json);
+    
+    std::unique_ptr<BearSSL::WiFiClientSecure>client(new BearSSL::WiFiClientSecure);
+    client->setInsecure();
+
+    HTTPClient https;
+    if(https.begin(*client, url) )
+    {   
+        // CONSOLELN(json);
+        https.addHeader("Content-Type", "application/json");
+        int httpCode = https.POST(json);
+        
+
+        if (httpCode > 0) 
+        {
+            if (httpCode == HTTP_CODE_OK || httpCode == HTTP_CODE_MOVED_PERMANENTLY)
+            {
+            CONSOLELN(F("Should be connected..."));
+            String payload = https.getString();
+            CONSOLELN(payload);
+            
+            }
+        
+            else
+            {
+            CONSOLE(F("Connection failed Code ") );
+            CONSOLELN(httpCode);
+            }
+        }
+      https.end();
+    }
+    else
+    {
+        CONSOLELN(F("Connection failed"));
+    }
+
+    
+    stopclient();
+    return true;
+}
 
 bool SenderClass::sendGenericPost(String server, String uri, uint16_t port)
 {

--- a/pio/lib/Sender/Sender.h
+++ b/pio/lib/Sender/Sender.h
@@ -21,6 +21,7 @@ public:
   String sendTCP(String server, uint16_t port = 80);
   bool sendThingSpeak(String token, long Channel);
   bool sendGenericPost(String server, String uri, uint16_t port = 80);
+  bool sendHTTPSPost(String server, String uri);
   bool sendInfluxDB(String server, uint16_t port, String db, String name, String username, String password);
   bool sendPrometheus(String server, uint16_t port, String job, String instance);
   bool sendUbidots(String token, String name);

--- a/pio/lib/WiFiManagerKT/WiFiManagerKT.h
+++ b/pio/lib/WiFiManagerKT/WiFiManagerKT.h
@@ -55,7 +55,8 @@ var lAPI = [
 {"name":"ThingSpeak", "token":1,"server":0,"uri":0,"port":0,"channel":1,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0},
 {"name":"Blynk",      "token":1,"server":0,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0},
 {"name":"Brewblox",   "token":0,"server":1,"uri":1,"port":1,"channel":0,"db":0,"username":1,"password":1,"job":0,"instance":0,"warning1":0},
-{"name":"AWSIOTMQTT", "token":0,"server":1,"uri":1,"port":1,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":1}];
+{"name":"AWSIOTMQTT", "token":0,"server":1,"uri":1,"port":1,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":1},
+{"name":"HTTPS Post", "token":1,"server":1,"uri":1,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0}];
 var $ = function (id) { return document.getElementById(id); };
 var labels = document.getElementsByTagName('LABEL');
 function set(id, show) {

--- a/pio/src/iSpindel.cpp
+++ b/pio/src/iSpindel.cpp
@@ -639,7 +639,7 @@ bool uploadData(uint8_t service)
 #endif
 
 #ifdef API_GENERIC
-  if ((service == DTHTTP) || (service == DTCraftBeerPi) || (service == DTiSPINDELde) || (service == DTTCP))
+  if ((service == DTHTTP) || (service == DTCraftBeerPi) || (service == DTiSPINDELde) || (service == DTTCP) || (service == DTHTTPS))
   {
 
     sender.add("name", my_name);
@@ -674,6 +674,11 @@ bool uploadData(uint8_t service)
       CONSOLELN(F("\ncalling TCP"));
       String response = sender.sendTCP(my_server, my_port);
       return processResponse(response);
+    }
+  	else if (service == DTHTTPS)
+    {
+      CONSOLELN(F("\ncalling HTTPS"));
+      return sender.sendHTTPSPost(my_server, my_uri);
     }
   }
 #endif // DATABASESYSTEM


### PR DESCRIPTION
Added a new sender to send POST data via HTTPS without  checking the certificate. This way it is possible to send data via POST to a https server. It is insecure, but the data sent here is typically not sensitive.

#405 #352 