### PR TITLE
TCP Data Fixes

### DIFF
--- a/pio/lib/Sender/Sender.cpp
+++ b/pio/lib/Sender/Sender.cpp
@@ -237,7 +237,7 @@ String SenderClass::sendTCP(String server, uint16_t port)
     }
     while (_client.available())
     {
-        response += _client.read();
+        response += (char)_client.read();
     }
     CONSOLELN(response);
     stopclient();

--- a/pio/lib/Sender/Sender.h
+++ b/pio/lib/Sender/Sender.h
@@ -43,7 +43,7 @@ public:
 private:
   WiFiClient _client;
   PubSubClient _mqttClient;
-  StaticJsonDocument<256> _doc;
+  StaticJsonDocument<1024> _doc;
   WiFiClientSecure _secureClient;
 };
 


### PR DESCRIPTION
The response from the TCP server was not being processed, when monitoring the response was in ASCII byte values, by casting the _client.Read to a char the response because text and was processed correctly. 

When sending TCP the RSSI was missing from JSON in the latest version, tracked that back to the size of the StaticJsonDocument _doc was reduced to 265 which is not big enough for the TCP data being sent