### PR TITLE
PlatformIO build configurations tweak (resolves  universam1/iSpindel#500)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,10 +49,10 @@ jobs:
     - name: Install library dependencies
       run: pio lib -g install 1
     - name: Run PlatformIO
-      run: pio run -e d1_mini
+      run: pio run -e d1_mini_git
     - name: Save firmware
       uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: .pio/build/d1_mini/firmware.bin
+        path: .pio/build/d1_mini_git/firmware.bin
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,11 +9,23 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = d1_mini
+default_envs = d1_mini_git
 lib_dir = pio/lib
 src_dir = pio/src
 
-[env:d1_mini]
+[common_env_data]
+lib_deps =
+  ArduinoJson@>5
+  ESP Async WebServer
+  I2Cdevlib-MPU6050
+  OneWire
+  DallasTemperature
+  RunningMedian
+  PubSubClient
+  Blynk
+  ThingSpeak
+
+[env:d1_mini_git]
 platform = espressif8266
 board = d1_mini
 framework = arduino
@@ -21,17 +33,18 @@ monitor_speed = 115200
 upload_speed = 115200
 build_flags = !python3 git_rev.py
 lib_deps =
-  ArduinoJson@>5
-  ESP Async WebServer
-  I2Cdevlib-MPU6050
-  OneWire
-  DallasTemperature
-  RunningMedian
-  PubSubClient
-  Blynk
-  ThingSpeak
+    ${common_env_data.lib_deps}
+
+[env:d1_mini_standalone]
+platform = espressif8266
+board = d1_mini
+framework = arduino
+monitor_speed = 115200
+upload_speed = 115200
+lib_deps =
+    ${common_env_data.lib_deps}
   
-[env:d1_mini_stage]
+[env:d1_mini_git_stage]
 platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
 board = d1_mini
 framework = arduino
@@ -39,12 +52,4 @@ monitor_speed = 115200
 upload_speed = 921600
 build_flags = !python3 git_rev.py
 lib_deps =
-  ArduinoJson@>5
-  ESP Async WebServer
-  I2Cdevlib-MPU6050
-  OneWire
-  DallasTemperature
-  RunningMedian
-  PubSubClient
-  Blynk
-  ThingSpeak
+    ${common_env_data.lib_deps}


### PR DESCRIPTION
Changes to platforio.ini to address https://github.com/universam1/iSpindel/issues/500 issue

1. Added new build configuration  d1_mini_standalone to be able to build from zip without having git installed
2. d1_mini renamed to d1_mini_git
3. d1_mini_stage renamed to d1_mini_git_stage