### PR TITLE
make tilt angle independent of the board orientation

### DIFF
--- a/pio/src/iSpindel.cpp
+++ b/pio/src/iSpindel.cpp
@@ -945,7 +945,7 @@ float calculateTilt()
   if (ax == 0 && ay == 0 && az == 0)
     return 0.f;
 
-  return acos(az / (sqrt(ax * ax + ay * ay + az * az))) * 180.0 / M_PI;
+  return acos(abs(az) / (sqrt(ax * ax + ay * ay + az * az))) * 180.0 / M_PI;
 }
 
 bool testAccel()


### PR DESCRIPTION
this solves #445 (yes, the calibration will account for the weird numbers, but it's nice to have a number one can relate to - for instance, instructions say the 1.000 angle should be 25 degrees - with the board inverted that would be 155 degrees, having to remember to subtract from 180 degrees is less than ideal :) )