### PR TITLE
Support SG on BierBot Bricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Die Einrichtung mit BierBot Bricks ist einfach und kostenlos. Ihr benötigt hier
 3. Dort klickt ihr nun auf den blauen "Add Brick" / "Brick hinzufügen" oben rechts.
 4. Wählt den "iSpindel"-Tab im Popup und kopiert den API key in die Zwischenablage.
 5. Ruft nun das Konfigurationsportal eurer iSpindel auf (die iSpindel erstellt einen Accesspoint durch mehrmaliges Drücken der Reset-Taste, s. [hier](#portal))
-6. Wählt als Service "Bricks (free & easy)" aus (siehe 2 im Bild).
+6. Wählt als Service "BierBot Bricks" aus (siehe 2 im Bild).
 7. Fügt nun unter "Token/ API key" den API key aus euer Zwischenablage ein und klickt ganz unten auf den blauen Speichern-Button.
 8. Geht nun zurück auf [bricks.bierbot.com](https://bricks.bierbot.com/#/) und wählt "Equipment" bzw. "Brauanlagen" auf der linken Seite aus (3 im Bild).
 9. Erstellt nun ein neues Gerät (blauber Button rechts oben) vom Typ "**Fermenter**".

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -156,7 +156,7 @@ The setup with BierBot Bricks is easy and for free. You will need the iSpindle F
 3. Hit the blue "Add Brick" button in the top right corner.
 4. Select "iSpindel" in the popup and copy the displayed API key into your clipboard.
 5. Now open the configuration portal of your iSpindel (by pressing reset multiple times, see [portal](#portal) for more info).
-6. Select "Bricks (free & easy)" as service (see 2 in the image).
+6. Select "BierBot Bricks" as service (see 2 in the image).
 7. Paste the api key from your clipboard into the "Token/ API key" field and hit the blue save bottom at the bottom.
 8. Now go back to [bricks.bierbot.com](https://bricks.bierbot.com/#/) and select "Equipment" in the menu on the left (see 3 in the image).
 9. Create a new device (blue button, top right corner), select "**Fermenter**" in the popup.

--- a/pio/src/iSpindel.cpp
+++ b/pio/src/iSpindel.cpp
@@ -788,7 +788,7 @@ bool uploadData(uint8_t service)
     sender.add("brand", "wemos_d1_mini");
     sender.add("version", FIRMWAREVERSION);
     sender.add("chipid", chipidHashed);
-    sender.add("s_number_wort_0", (float)(round(Gravity * 1000) / 1000));
+    sender.add("s_number_wort_0", (float)(round(Gravity * 10000) / 10000));
     sender.add("s_number_temp_0", (float)(round(Temperatur * 10) / 10)); // always transmit °C
     sender.add("s_number_voltage_0", (float)round(Volt * 100) / 100);
     sender.add("s_number_wifi_0", WiFi.RSSI());

--- a/pio/src/iSpindel.cpp
+++ b/pio/src/iSpindel.cpp
@@ -788,7 +788,7 @@ bool uploadData(uint8_t service)
     sender.add("brand", "wemos_d1_mini");
     sender.add("version", FIRMWAREVERSION);
     sender.add("chipid", chipidHashed);
-    sender.add("s_number_wort_0", (float)(round(Gravity * 10) / 10));
+    sender.add("s_number_wort_0", (float)(round(Gravity * 1000) / 1000));
     sender.add("s_number_temp_0", (float)(round(Temperatur * 10) / 10)); // always transmit °C
     sender.add("s_number_voltage_0", (float)round(Volt * 100) / 100);
     sender.add("s_number_wifi_0", WiFi.RSSI());

--- a/pio/src/iSpindel.cpp
+++ b/pio/src/iSpindel.cpp
@@ -788,11 +788,11 @@ bool uploadData(uint8_t service)
     sender.add("brand", "wemos_d1_mini");
     sender.add("version", FIRMWAREVERSION);
     sender.add("chipid", chipidHashed);
-    sender.add("s_number_wort_0", (float)(round(Gravity * 10000) / 10000));
-    sender.add("s_number_temp_0", (float)(round(Temperatur * 10) / 10)); // always transmit °C
-    sender.add("s_number_voltage_0", (float)round(Volt * 100) / 100);
+    sender.add("s_number_wort_0", Gravity); // gravity can be in SG or °P, depending on user setting
+    sender.add("s_number_temp_0", Temperatur); // always transmit °C
+    sender.add("s_number_voltage_0", Volt);
     sender.add("s_number_wifi_0", WiFi.RSSI());
-    sender.add("s_number_tilt_0", (float)(round(Tilt * 100) / 100));
+    sender.add("s_number_tilt_0", Tilt);
 
     CONSOLELN(F("\ncalling BRICKS"));
 

--- a/pio/src/iSpindel.cpp
+++ b/pio/src/iSpindel.cpp
@@ -788,7 +788,7 @@ bool uploadData(uint8_t service)
     sender.add("brand", "wemos_d1_mini");
     sender.add("version", FIRMWAREVERSION);
     sender.add("chipid", chipidHashed);
-    sender.add("s_number_wort_0", Gravity); // gravity can be in SG or °P, depending on user setting
+    sender.add("s_number_wort_0", Gravity);    // gravity can be in SG or °P, depending on user setting
     sender.add("s_number_temp_0", Temperatur); // always transmit °C
     sender.add("s_number_voltage_0", Volt);
     sender.add("s_number_wifi_0", WiFi.RSSI());


### PR DESCRIPTION
If iSpindel transmits SG (and not °P) 1 decimal (1.0, `round(x*10)/10`) is not sufficient. This PR ensures, that 4 decimals are send to the BierBot Bricks backend. This way, gravity values like SG=1.0482 can be transmitted to the BierBot Bricks backend without loss of information. 