### PR TITLE
Adding support for InfluxDB in HTTPS mode

### DIFF
--- a/pio/lib/Globals/Globals.h
+++ b/pio/lib/Globals/Globals.h
@@ -156,6 +156,7 @@ struct iData
 #if API_MQTT_HASSIO
   bool hassio = false;
 #endif
+  bool usehttps = false;
 };
 
 extern iData myData;

--- a/pio/lib/Sender/Sender.cpp
+++ b/pio/lib/Sender/Sender.cpp
@@ -459,7 +459,7 @@ bool SenderClass::sendGenericPost(String server, String uri, uint16_t port)
   return true;
 }
 
-bool SenderClass::sendInfluxDB(String server, uint16_t port, String db, String name, String username, String password)
+bool SenderClass::sendInfluxDB(String server, uint16_t port, String db, String name, String username, String password, bool usehttps)
 {
   HTTPClient http;
 
@@ -468,7 +468,16 @@ bool SenderClass::sendInfluxDB(String server, uint16_t port, String db, String n
 
   CONSOLELN(String(F("INFLUXDB: posting to db: ")) + uri);
   // configure traged server and uri
-  http.begin(_client, server, port, uri);
+
+  if (usehttps == true)
+  {
+    _secureClient.setInsecure();
+    http.begin(_secureClient, server, port, uri);
+  }
+  else
+  {
+    http.begin(_client, server, port, uri);
+  }
 
   if (username.length() > 0)
   {

--- a/pio/lib/Sender/Sender.h
+++ b/pio/lib/Sender/Sender.h
@@ -25,7 +25,7 @@ public:
   bool sendThingSpeak(String token, long Channel);
   bool sendGenericPost(String server, String uri, uint16_t port = 80);
   bool sendHTTPSPost(String server, String uri);
-  bool sendInfluxDB(String server, uint16_t port, String db, String name, String username, String password);
+  bool sendInfluxDB(String server, uint16_t port, String db, String name, String username, String password, bool usehttps);
   bool sendPrometheus(String server, uint16_t port, String job, String instance);
   bool sendUbidots(String token, String name);
   bool sendMQTT(String server, uint16_t port, String username, String password, String name);

--- a/pio/lib/WiFiManagerKT/WiFiManagerKT.h
+++ b/pio/lib/WiFiManagerKT/WiFiManagerKT.h
@@ -41,23 +41,23 @@ const char HTTP_STYLE[] PROGMEM = "<style>body,textarea,input,select{background:
 const char HTTP_SCRIPT[] PROGMEM = R"V0G0N(
 <script>
 var lAPI = [
-{"name":"Ubidots",    "token":1,"server":0,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0},
-{"name":"empty",      "token":1,"server":0,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0},
-{"name":"CraftBeerPi","token":0,"server":1,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0},
-{"name":"HTTP",       "token":1,"server":1,"uri":1,"port":1,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0},
-{"name":"TControl",   "token":0,"server":1,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0},
-{"name":"FHEM",       "token":0,"server":1,"uri":0,"port":1,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0},
-{"name":"TCP",        "token":1,"server":1,"uri":0,"port":1,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0},
-{"name":"iSpindel.de","token":1,"server":0,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0},
-{"name":"InfluxDB",   "token":0,"server":1,"uri":0,"port":1,"channel":0,"db":1,"username":1,"password":1,"job":0,"instance":0,"warning1":0,"hassio":0},
-{"name":"Prometheus", "token":0,"server":1,"uri":0,"port":1,"channel":0,"db":0,"username":0,"password":0,"job":1,"instance":1,"warning1":0,"hassio":0},
-{"name":"MQTT",       "token":0,"server":1,"uri":0,"port":1,"channel":0,"db":0,"username":1,"password":1,"job":0,"instance":0,"warning1":0,"hassio":1},
-{"name":"ThingSpeak", "token":1,"server":0,"uri":0,"port":0,"channel":1,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0},
-{"name":"Blynk",      "token":1,"server":0,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0},
-{"name":"Brewblox",   "token":0,"server":1,"uri":1,"port":1,"channel":0,"db":0,"username":1,"password":1,"job":0,"instance":0,"warning1":0,"hassio":0},
-{"name":"AWSIOTMQTT", "token":0,"server":1,"uri":1,"port":1,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":1,"hassio":0},
-{"name":"HTTPS Post", "token":1,"server":1,"uri":1,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0},
-{"name":"BierBot Bricks", "token":1,"server":0,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0}
+{"name":"Ubidots",       "token":1,"server":0,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":0},
+{"name":"empty",         "token":1,"server":0,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":0},
+{"name":"CraftBeerPi",   "token":0,"server":1,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":0},
+{"name":"HTTP",          "token":1,"server":1,"uri":1,"port":1,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":0},
+{"name":"TControl",      "token":0,"server":1,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":0},
+{"name":"FHEM",          "token":0,"server":1,"uri":0,"port":1,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":0},
+{"name":"TCP",           "token":1,"server":1,"uri":0,"port":1,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":0},
+{"name":"iSpindel.de",   "token":1,"server":0,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":0},
+{"name":"InfluxDB",      "token":0,"server":1,"uri":0,"port":1,"channel":0,"db":1,"username":1,"password":1,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":1},
+{"name":"Prometheus",    "token":0,"server":1,"uri":0,"port":1,"channel":0,"db":0,"username":0,"password":0,"job":1,"instance":1,"warning1":0,"hassio":0,"usehttps":0},
+{"name":"MQTT",          "token":0,"server":1,"uri":0,"port":1,"channel":0,"db":0,"username":1,"password":1,"job":0,"instance":0,"warning1":0,"hassio":1,"usehttps":0},
+{"name":"ThingSpeak",    "token":1,"server":0,"uri":0,"port":0,"channel":1,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":0},
+{"name":"Blynk",         "token":1,"server":0,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":0},
+{"name":"Brewblox",      "token":0,"server":1,"uri":1,"port":1,"channel":0,"db":0,"username":1,"password":1,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":0},
+{"name":"AWSIOTMQTT",    "token":0,"server":1,"uri":1,"port":1,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":1,"hassio":0,"usehttps":0},
+{"name":"HTTPS Post",    "token":1,"server":1,"uri":1,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":0},
+{"name":"BierBot Bricks","token":1,"server":0,"uri":0,"port":0,"channel":0,"db":0,"username":0,"password":0,"job":0,"instance":0,"warning1":0,"hassio":0,"usehttps":0}
 ];
 
 var $ = function (id) { return document.getElementById(id); };


### PR DESCRIPTION
For security purposes, it is inadvisable to run InfluxDB on the public-facing internet in HTTP mode (for example, on a VPS).

This commit adds a checkbox to the InfluxDB service to enable HTTPS, for use with servers that are configured for it.

Compiled and running/sending successfully in both HTTP and HTTPS mode on a Lolin Wemos D1 Mini v4.