### PR TITLE
Add unit_of_meas to tilt for HA MQTT integration

### DIFF
--- a/pio/lib/Sender/Sender.cpp
+++ b/pio/lib/Sender/Sender.cpp
@@ -209,8 +209,8 @@ bool SenderClass::enableHassioDiscovery(String server, uint16_t port, String use
                         true);
     _mqttClient.publish((topic + "tilt/config").c_str(),
                         ("{ \"uniq_id\": \"" + chipid +
-                         "_tilt\", \"name\": \"Tilt\", \"val_tpl\": \"{{ value_json }}\", \"stat_t\": \"ispindel/" +
-                         name + "/tilt\"," + device + "}")
+                         "_tilt\", \"name\": \"Tilt\",  \"unit_of_meas\": \"°\", \"val_tpl\": \"{{ value_json }}\"" + 
+                         ", \"stat_t\": \"ispindel/" + name + "/tilt\"," + device + "}")
                             .c_str(),
                         true);
     _mqttClient.publish((topic + "battery/config").c_str(),


### PR DESCRIPTION
This adds the unit_of_meas to the tilt Home Assistant configuration topic to let HA show a line graph instead of the state history.

Fixes #588