### PR TITLE
Repair for ArduinoJson 6.20.0

### DIFF
--- a/pio/lib/Sender/Sender.cpp
+++ b/pio/lib/Sender/Sender.cpp
@@ -496,7 +496,7 @@ bool SenderClass::sendInfluxDB(String server, uint16_t port, String uri, String 
     msg += kv.key().c_str();
     msg += "=";
     // check if value is of type char, if so set value in double quotes
-    if (kv.value().is<char *>())
+    if (kv.value().is<const char *>())
     {
       msg += '"' + kv.value().as<String>() + '"';
     }


### PR DESCRIPTION
I couldn't compile the project and experienced the following error:
`pio/lib/Sender/Sender.cpp:499:31: error: no matching function for call to 'ArduinoJson6200_F1::JsonVariant::is<char*>()'`

I browsed ArduinoJson's documentation and came upon the following line on [the page documenting the JsonVariant::is<T>()](https://arduinojson.org/v6/api/jsonvariant/is/) function:
`bool is<char*>() const;  // ⚠️ deprecated since 6.18`

After applying the change you will find in this PR, I was able to compile the project and upload it to a NodeMCU but I couldn't fully test the iSpindel as I am missing some sensors at the moment.