### PR TITLE
Lock version on ESP Async

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ src_dir = pio/src
 [common_env_data]
 lib_deps = 
 	ArduinoJson@<7
-	ESP Async WebServer
+	ESP32Async/ESPAsyncTCP @ 2.0.0
 	OneWire
 	DallasTemperature
 	RunningMedian


### PR DESCRIPTION
Appears https://github.com/me-no-dev/AsyncTCP went readonly on 1/20/2025 and is now suggesting using ESP32Async/ESPAsyncTCP @ 2.0.0. I also tried using ESP32Async/ESPAsyncWebServer @ 3.6.0, however it wanted to pull in some FreeRTOS dependancies and didn't seem to provide much benefit for this project. 

Initial testing seems to indicate that this fixes the current build issue without the lock on version number and doesn't impact functionality.